### PR TITLE
use crypto.random bytes instead of math.random

### DIFF
--- a/lib/phonetic.js
+++ b/lib/phonetic.js
@@ -178,7 +178,7 @@ function getOptions(overrides) {
 	var options = {};
 	overrides = overrides || {};
 	options.syllables = overrides.syllables || 3;
-	options.seed = overrides.seed || Math.random();
+	options.seed = overrides.seed || crypto.randomBytes(16).toString('base64');
 	options.phoneticSimplicity = overrides.phoneticSimplicity ?
 		Math.max(overrides.phoneticSimplicity, 1) : 5;
 	options.compoundSimplicity = overrides.compoundSimplicity ?


### PR DESCRIPTION
I mean you're in node allready, note the v8 math.random has historically been really bad, it is being updated in the next version but node isn't going to get that until version 6 at least
